### PR TITLE
Start the daemon in linux.

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,14 +22,14 @@ if (parsed.config) {
 
 var daemon = require('./lib/daemon')()
 
-if (!parsed.daemon && process.platform === 'darwin') {
+if (!parsed.daemon && (process.platform === 'darwin' || process.platform === 'linux')) {
   daemon.start()
 }
 
 var app = require('app')
 app.on('ready', setup)
 app.on('window-all-closed', function() {
-  if (process.platform !== 'darwin') {
+  if (process.platform !== 'darwin' || process.platform !== 'linux') {
     app.quit()
   }
 })

--- a/lib/daemon.js
+++ b/lib/daemon.js
@@ -36,11 +36,17 @@ Daemon.prototype.start = function() {
   this.child.on('error', function(err) {
     log(err.message)
   })
-  this.child.on('exit', function(code) {
-    log(`daemon exited with code ${code}`)
-    self.running = false
-    self.emit('stopped')
-  })
+
+  // Linux always returns an exit status of 0 when starting the daemon.
+  // TODO better error handling for linux; in the event the daemon doesn't start
+  // the current behavior is to open the electron app anyway with blank info.
+  if(process.platform !== 'linux') {
+    this.child.on('exit', function(code) {
+      log(`daemon exited with code ${code}`)
+      self.running = false
+      self.emit('stopped')
+    })
+  }
 }
 
 Daemon.prototype.stop = function() {


### PR DESCRIPTION
Because the daemon in linux spawns a separate process to run the daemon and returns
an exit status of 0 there is no running child to kill when stopping the app.

Should fallback to RPC stop command.
